### PR TITLE
fix: allow preload to expose electronAPI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -81,7 +81,7 @@ function createWindow() {
       nodeIntegration: false,
       contextIsolation: true,
       // Enable sandbox for better security on Mac
-      sandbox: false, // Set to false to allow preload script to work properly
+      sandbox: true,
     },
     title: 'Dev Tools Manager',
     // Mac-specific: show window when ready to prevent white flash


### PR DESCRIPTION
尝试修复 Windows 中 `npm run dev` 无法启动以及 v1.5.1 / v1.5.2 无法启动的问题

<img width="705" height="393" alt="PixPin_2026-01-18_15-06-30" src="https://github.com/user-attachments/assets/0a592fc3-1813-4f04-88d4-1c6136dc4cdf" />

---

请验证是否有效