### PR TITLE
fix(ai-catalog): use Amp manual URL

### DIFF
--- a/scripts/ai-cli-catalog.json
+++ b/scripts/ai-cli-catalog.json
@@ -20,7 +20,7 @@
     { "id": "copilot", "docsUrl": "https://github.com/github/copilot-cli", "registry": { "type": "npm", "name": "@github/copilot" } },
     { "id": "qwen", "docsUrl": "https://github.com/QwenLM/qwen-code", "registry": { "type": "npm", "name": "@qwen-code/qwen-code" } },
     { "id": "cline", "docsUrl": "https://cline.bot", "registry": { "type": "npm", "name": "cline" } },
-    { "id": "amp", "docsUrl": "https://ampcode.com/" },
+    { "id": "amp", "docsUrl": "https://ampcode.com/manual" },
     { "id": "crush", "docsUrl": "https://charm.sh/crush", "registry": { "type": "npm", "name": "@charmland/crush" } },
     { "id": "droid", "docsUrl": "https://docs.factory.ai/reference/cli-reference", "registry": { "type": "npm", "name": "droid" } },
     { "id": "vibe", "docsUrl": "https://docs.mistral.ai/vibe/code/cli/install-setup", "registry": { "type": "pypi", "name": "mistral-vibe" } },

--- a/src-tauri/src/ai_tools/mod.rs
+++ b/src-tauri/src/ai_tools/mod.rs
@@ -304,7 +304,7 @@ static AI_TOOLS: &[AiToolMetadata] = &[
         id: "amp",
         name: "Amp",
         description: "Sourcegraph's agentic coding tool for the terminal",
-        docs_url: "https://ampcode.com/",
+        docs_url: "https://ampcode.com/manual",
         commands: &["amp"],
         version_args: &["--version"],
         version_regex: Some(r"(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z\.-]+)?)"),


### PR DESCRIPTION
## Summary

- point the Amp catalog entry at its official public manual
- keep the Rust tool metadata and audit catalog in sync
- avoid Node fetch header overflow caused by the Amp homepage preload headers

## Validation

- `corepack pnpm validate:ai-catalog`
- `node scripts/audit-ai-catalog.mjs --network`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked --no-default-features --lib ai_tools`
- `git diff --check`